### PR TITLE
feat: IAM role and policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ node_modules/
 cdk.context.json
 cdk.out/
 .cdk.staging
+package-lock.json
 

--- a/assume_role.sh
+++ b/assume_role.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "No profile provided. Usage: $0 <profile_name>"
+    exit 1
+fi
+
+PROFILE=$1
+export AWS_PROFILE=$PROFILE
+
+ROLE_ARN=$(aws cloudformation describe-stacks --stack-name IamStack --query "Stacks[0].Outputs[?ExportName=='HeliosDeploymentRoleArn'].OutputValue" --output text)
+
+if [ -z "$ROLE_ARN" ]; then
+    echo "Error: Unable to retrieve the deployment role ARN. Make sure the IamStack has been deployed."
+    exit 1
+fi
+
+# Assume the role and get temporary credentials
+CREDENTIALS=$(aws sts assume-role --role-arn $ROLE_ARN --role-session-name DeploymentSession --output text --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]')
+
+if [ $? -ne 0 ]; then
+    echo "Error: Failed to assume the deployment role."
+    exit 1
+fi
+
+# Read the credentials into an array
+IFS=$'\t' read -r -a cred_array <<< "$CREDENTIALS"
+
+# Export the credentials as environment variables
+export AWS_ACCESS_KEY_ID="${cred_array[0]}"
+export AWS_SECRET_ACCESS_KEY="${cred_array[1]}"
+export AWS_SESSION_TOKEN="${cred_array[2]}"
+
+echo "Temporary credentials set. You can now run 'cdk deploy --all'."

--- a/bin/cdk_deploy.js
+++ b/bin/cdk_deploy.js
@@ -5,6 +5,7 @@ const { ClickhouseEc2Stack } = require('../lib/clickhouse-ec2-stack');
 const { FlaskEc2Stack } = require('../lib/flask-ec2-stack');
 const { DynamoDbStack } = require('../lib/dynamodb-stack');
 const { LambdaStack } = require('../lib/lambda-stack');
+const { IamStack } = require('../lib/iam-stack');
 
 const app = new cdk.App();
 
@@ -12,6 +13,8 @@ const env = {
   account: process.env.CDK_DEFAULT_ACCOUNT,
   region: process.env.CDK_DEFAULT_REGION
 }
+
+const iamStack = new IamStack(app, 'IamStack', { env });
 
 const vpcStack = new VpcStack(app, 'VpcStack', { env });
 
@@ -43,6 +46,7 @@ const lambdaStack = new LambdaStack(app, 'LambdaStack', {
   publicSubnetIds: vpcStack.vpc.publicSubnets.map(subnet => subnet.subnetId),
 });
 
+vpcStack.addDependency(iamStack);
 clickhouseEc2Stack.addDependency(vpcStack);
 lambdaStack.addDependency(clickhouseEc2Stack);
 dynamoDbStack.addDependency(vpcStack);

--- a/cdk_policy.json
+++ b/cdk_policy.json
@@ -1,0 +1,26 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:AttachRolePolicy",
+                "iam:PutRolePolicy",
+                "cloudformation:CreateStack",
+                "cloudformation:DescribeStacks",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:GetTemplate",
+                "s3:CreateBucket",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketPublicAccessBlock",
+                "ssm:PutParameter",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/deployment.md
+++ b/deployment.md
@@ -1,0 +1,70 @@
+# CLI
+
+## all steps in order:
+
+0. prereq
+   - they need an AWS IAM account
+   - theyve npm installed the npm package that includes all cdk directories/files (e.g. bin/, lib/, scripts/, package.json, \*.zip)
+1. manual - install aws cli
+   - https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+2. CLI interaction -- they give us their profile name (that either already exists or that they plan on us creating for them)
+3. manual (potential automate) - if they dont already have an access key...
+   create access key and add to `~/.aws/credentials` and `~/.aws/config`
+   - `aws iam create-access-key --user-name ${USERNAME}`
+   - Potential to automate this process by calling using aws CLI to create access key and then use the output to create a profile with given name
+   - if they dont have ability to create an access key, can get it by creating below policy with their root account and attaching to their IAM user
+   ```
+   {
+   "Version": "2012-10-17",
+   "Statement": [
+       {
+           "Effect": "Allow",
+           "Action": [
+               "iam:CreateAccessKey",
+               "iam:DeleteAccessKey",
+               "iam:GetAccessKeyLastUsed",
+               "iam:ListAccessKeys",
+               "iam:UpdateAccessKey"
+           ],
+           "Resource": "arn:aws:iam::*:user/test-deploy-iam"
+       }
+   ]
+   }
+   ```
+4. manual - if their IAM user does not have the ability to create and attach policies ...
+   from their root account, attach a policy to their IAM user, policies (most likely they already have this ability, but worth noting)
+
+   ```
+   {
+       "Version": "2012-10-17",
+       "Statement": [
+           {
+               "Effect": "Allow",
+               "Action": [
+                   "iam:AttachUserPolicy",
+                   "iam:DetachUserPolicy",
+                   "iam:ListAttachedUserPolicies",
+                   "iam:ListUserPolicies",
+                   "iam:PutUserPolicy",
+                   "iam:DeleteUserPolicy",
+                   "iam:GetUserPolicy",
+                   "iam:SimulatePrincipalPolicy",
+                   "iam:ListPolicies",
+                   "iam:GetPolicy",
+                   "iam:GetPolicyVersion",
+                   "iam:ListPolicyVersions",
+                   "iam:CreatePolicy",
+                   "iam:DeletePolicy",
+                   "iam:CreatePolicyVersion",
+                   "iam:DeletePolicyVersion",
+                   "iam:SetDefaultPolicyVersion",
+                   "iam:GetUser"
+               ],
+               "Resource": "*"
+           }
+       ]
+   }
+   ```
+
+5. CLI runs `export AWS_PROFILE=${profile_name}`
+6. CLI runs `chmod +x setup.sh && . ./setup.sh`

--- a/lib/iam-stack.js
+++ b/lib/iam-stack.js
@@ -1,0 +1,29 @@
+const { Stack, CfnOutput } = require('aws-cdk-lib');
+const iam = require('aws-cdk-lib/aws-iam');
+
+class IamStack extends Stack {
+  constructor(scope, id, props) {
+    super(scope, id, props);
+
+    const deploymentRole = new iam.Role(this, 'DeploymentRole', {
+      assumedBy: new iam.AccountPrincipal(this.account),
+      roleName: 'HeliosDeploymentRole',
+      description: 'Role for deploying Helios project resources',
+    });
+
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSCloudFormationFullAccess'));
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonEC2FullAccess'));
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonDynamoDBFullAccess'));
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AWSLambda_FullAccess'));
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('IAMFullAccess'));
+    deploymentRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMFullAccess'));
+
+    new CfnOutput(this, 'DeploymentRoleArn', {
+      value: deploymentRole.roleArn,
+      description: 'ARN of the deployment role',
+      exportName: 'HeliosDeploymentRoleArn',
+    });
+  }
+}
+
+module.exports = { IamStack };

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+#set -x # testing
+
+error_handler() {
+    local line=$1
+    local command=$2
+    local error_code=${3:-1}
+    echo "Error occurred in command '$command' on line $line. Exit code: $error_code" >&2
+    say "helios infrastructure setup failed"
+    exit $error_code
+}
+
+trap 'error_handler ${LINENO} "$BASH_COMMAND" $?' ERR
+
+main() {
+    echo "Starting Helios infrastructure setup..."
+
+    read -p "Enter the IAM profile name: " PROFILE
+    echo "1-Using profile: $PROFILE"
+    export AWS_PROFILE=$PROFILE
+
+    chmod +x setup_cdk.sh assume_role.sh
+    
+    echo "Running setup_cdk.sh..."
+    bash ./setup_cdk.sh $PROFILE
+    
+    echo "Deploying IamStack..."
+    cdk deploy IamStack --require-approval never
+    
+    echo "Assuming deployment role..."
+    bash ./assume_role.sh $PROFILE
+    
+    echo "Deploying all stacks..."
+    if cdk deploy --all --require-approval never; then
+        say "helios infrastructure setup done"
+        echo "Deployment completed successfully!"
+    else
+        say "helios infrastructure setup failed"
+        echo "Deployment failed. Check the logs for more information." >&2
+        exit 1
+    fi
+}
+
+main

--- a/setup_cdk.sh
+++ b/setup_cdk.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -eq 0 ]; then
+    echo "No profile provided. Usage: $0 <profile_name>"
+    exit 1
+fi
+
+PROFILE=$1
+echo "2-Using profile: $PROFILE"
+export AWS_PROFILE=$PROFILE
+
+command_exists () {
+    type "$1" &> /dev/null ;
+}
+
+if ! command_exists aws ; then
+    echo "AWS CLI is not installed. Please install it and configure your credentials."
+    exit 1
+fi
+
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region)
+USERNAME=$(aws sts get-caller-identity --query Arn --output text | cut -d'/' -f2)
+
+echo "Setting up CDK for Account ID: $ACCOUNT_ID in Region: $REGION for User: $USERNAME"
+
+if aws iam get-policy --policy-arn arn:aws:iam::${ACCOUNT_ID}:policy/CDKDeploymentPolicy 2>/dev/null; then
+    echo "CDKDeploymentPolicy already exists. Skipping policy creation."
+    POLICY_ARN="arn:aws:iam::${ACCOUNT_ID}:policy/CDKDeploymentPolicy"
+else
+    echo "Creating CDK policy..."
+cat << EOF > cdk_policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "iam:CreateRole",
+                "iam:AttachRolePolicy",
+                "iam:PutRolePolicy",
+                "cloudformation:CreateStack",
+                "cloudformation:DescribeStacks",
+                "cloudformation:CreateChangeSet",
+                "cloudformation:DescribeChangeSet",
+                "cloudformation:ExecuteChangeSet",
+                "cloudformation:GetTemplate",
+                "s3:CreateBucket",
+                "s3:PutBucketPolicy",
+                "s3:PutBucketVersioning",
+                "s3:PutBucketPublicAccessBlock",
+                "ssm:PutParameter",
+                "sts:AssumeRole"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+
+    POLICY_ARN=$(aws iam create-policy --policy-name CDKDeploymentPolicy --policy-document file://cdk_policy.json --query 'Policy.Arn' --output text)
+    echo "CDK policy created with ARN: $POLICY_ARN"
+fi
+
+wait_for_iam_propagation() {
+    echo "Waiting for IAM changes to propagate..."
+    sleep 15
+}
+
+if aws iam list-attached-user-policies --user-name $USERNAME --query "AttachedPolicies[?PolicyArn=='$POLICY_ARN']" --output text | grep -q "$POLICY_ARN"; then
+    echo "Policy is already attached to user $USERNAME. Skipping attachment."
+else
+    echo "Attaching policy to user $USERNAME..."
+    aws iam attach-user-policy --user-name $USERNAME --policy-arn $POLICY_ARN
+    wait_for_iam_propagation
+fi
+
+echo "Installing AWS CDK globally..."
+if command_exists npm ; then
+    npm install -g aws-cdk
+else
+    echo "npm is not installed. Please install Node.js and npm to continue."
+    exit 1
+fi
+
+echo "Bootstrapping CDK..."
+if command_exists cdk ; then
+    cdk bootstrap aws://$ACCOUNT_ID/$REGION
+else
+    echo "CDK is not in the PATH. Make sure the npm global bin directory is in your PATH."
+    exit 1
+fi
+
+echo "CDK setup complete!"


### PR DESCRIPTION
## Overview

Created IAM role with a set of policies attached which users assume when deploying the app. Added a bash script `setup.sh` that automates the CDK setup, the process of assuming a role and the deployments of all stacks.

## Changes

- IamStack in CDK -- creates a role with policies for interacting with all services needed to deploy project infrastructure.
- Wrote some bash scripts in order to test full deployment of project from a new IAM AWS account.

## Notes for Reviewers

- As currently written, CLI must first deploy IamStack, then run the `assume_role.sh` script, then can deploy the rest of the Stacks
- We wrote a `setup_cdk.sh` script, but may also simply request that users install the CDK on their own as a prereq to using our project.
- We assume that the user has installed node and is using v.20+
- We wrote out some ideas for the CLI workflow in `deployment.md`
