### PR TITLE
feat: provide url to flask app with port 5000 after deployment finishes

### DIFF
--- a/src/utils/run-deploy.js
+++ b/src/utils/run-deploy.js
@@ -20,6 +20,7 @@ async function runDeploy(profile) {
   let currentStep = null;
   let buffer = "";
   let lastPrintedMessages = {};
+  let flaskIpAddress = null;
 
   const updateSpinner = (stepName, text, isError = false) => {
     let step = steps.find((s) => s.name === stepName);
@@ -64,6 +65,14 @@ async function runDeploy(profile) {
       let isError = false;
 
       line = line.replace(/\s+/g, " ").trim();
+
+      const flaskIpMatch = line.match(
+        /FlaskEc2Stack\.FlaskInstancePublicIp\s*=\s*(\d+\.\d+\.\d+\.\d+)/,
+      );
+      if (flaskIpMatch) {
+        flaskIpAddress = flaskIpMatch[1];
+        return;
+      }
 
       const updateSpinnerAndHandle = (stepName, text, isComplete = false) => {
         updateSpinner(stepName, isComplete ? `${stepName} deployed` : text);
@@ -195,6 +204,13 @@ async function runDeploy(profile) {
             "Helios infrastructure setup completed successfully",
           ),
         );
+        if (flaskIpAddress) {
+          console.log(
+            chalk.bold.blue(
+              `You can access your Flask application at: http://${flaskIpAddress}:5000`,
+            ),
+          );
+        }
         resolve();
       } else {
         console.error(chalk.bold.red(`Deployment failed with code ${code}`));


### PR DESCRIPTION
## Overview

As the final line output when running `helios deploy` as a user of our CLI, will now output a link to the web app

## Screenshots
![CleanShot 2024-07-26 at 09 10 48](https://github.com/user-attachments/assets/d8f2bf70-fc23-4acb-bfbf-1d5caab27c22)

## Notes for Reviewers
The `http` protocol and `5000` port align to how the CDK infra is currently set up. Ideally as a next step we would add a load balancer or API Gateway in front of the FlaskEc2Stack so that we can provide users with `https` access to the web app