### PR TITLE
feat: prompt user in cli for chatgpt api key

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,17 +1,41 @@
 #!/usr/bin/env node
-const process = require('process');
+const process = require("process");
+const readline = require("readline/promises");
+const path = require("path");
+const fs = require("fs/promises");
 const { outputValidArguments } = require("../src/utils/valid-arguments");
 const { setProfile } = require("../src/utils/set-profile");
 const { runDeploy } = require("../src/utils/run-deploy");
 const { runDestroy } = require("../src/utils/run-destroy.js");
 const { heliosArt } = require("../src/ascii/heliosAscii.js");
+const { input, confirm } = require("@inquirer/prompts");
+
+
+async function getChatGPTApiKey() {
+  const wantApiKey = await confirm({
+    message: "Would you like to provide a ChatGPT API key?",
+  });
+
+  if (wantApiKey) {
+    const apiKey = await input({
+      message: "Please enter your ChatGPT API key:",
+    });
+    console.log(apiKey);
+
+    const envPath = path.resolve(process.cwd(), ".env");
+    await fs.appendFile(envPath, `\nchatGptApiKey=${apiKey}`);
+    return apiKey;
+  } else {
+    return null;
+  }
+}
 
 
 let profile;
 
 async function setup() {
-  // heliosArt();
   profile = await setProfile();
+  await getChatGPTApiKey();
   await runDeploy(profile);
 }
 
@@ -19,17 +43,16 @@ async function main() {
   const arg = process.argv[2];
   if (arg === undefined) {
     setup();
-    // outputValidArguments();
-  } else if ( arg === 'deploy') {
+  } else if (arg === "deploy") {
     heliosArt();
     setup();
-  } else if (arg === 'destroy') {
+  } else if (arg === "destroy") {
     if (!profile) {
       profile = await setProfile();
     }
     runDestroy(profile);
   } else {
-    console.log('Invalid argument.');
+    console.log("Invalid argument.");
     outputValidArguments();
   }
 }

--- a/lib/flask-ec2-stack.js
+++ b/lib/flask-ec2-stack.js
@@ -1,26 +1,41 @@
-const { Stack, CfnOutput, Fn } = require('aws-cdk-lib');
-const ec2 = require('aws-cdk-lib/aws-ec2');
-const iam = require('aws-cdk-lib/aws-iam');
+const { Stack, CfnOutput, Fn } = require("aws-cdk-lib");
+const ec2 = require("aws-cdk-lib/aws-ec2");
+const iam = require("aws-cdk-lib/aws-iam");
+require("dotenv").config();
 
 class FlaskEc2Stack extends Stack {
   constructor(scope, id, props) {
     super(scope, id, props);
 
-    const vpc = ec2.Vpc.fromVpcAttributes(this, 'ImportedVpc', {
+    const vpc = ec2.Vpc.fromVpcAttributes(this, "ImportedVpc", {
       vpcId: props.vpcId,
       availabilityZones: props.availabilityZones,
       publicSubnetIds: props.publicSubnetIds,
-      publicSubnetRouteTableIds: [Fn.importValue('MainPublicSubnetRouteTableId')],
+      publicSubnetRouteTableIds: [
+        Fn.importValue("MainPublicSubnetRouteTableId"),
+      ],
     });
 
-    const flaskSecurityGroup = new ec2.SecurityGroup(this, 'FlaskSecurityGroup', {
-      vpc,
-      description: 'Security group for Flask EC2 instance',
-      allowAllOutbound: true,
-    });
+    const flaskSecurityGroup = new ec2.SecurityGroup(
+      this,
+      "FlaskSecurityGroup",
+      {
+        vpc,
+        description: "Security group for Flask EC2 instance",
+        allowAllOutbound: true,
+      },
+    );
 
-    flaskSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(5000), 'Allow Flask traffic');
-    flaskSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(22), 'Allow SSH access');
+    flaskSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(5000),
+      "Allow Flask traffic",
+    );
+    flaskSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(22),
+      "Allow SSH access",
+    );
 
     // const clickhouseSecurityGroup = ec2.SecurityGroup.fromSecurityGroupId(
     //   this,
@@ -29,52 +44,55 @@ class FlaskEc2Stack extends Stack {
     // );
     // flaskSecurityGroup.addEgressRule(clickhouseSecurityGroup, ec2.Port.tcp(8123), 'Allow traffic to ClickHouse');
 
-    const role = new iam.Role(this, 'FlaskEC2Role', {
-      assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
+    const role = new iam.Role(this, "FlaskEC2Role", {
+      assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
     });
 
     // Add managed policies
-    role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
-    role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy'));
+    role.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName(
+        "AmazonSSMManagedInstanceCore",
+      ),
+    );
+    role.addManagedPolicy(
+      iam.ManagedPolicy.fromAwsManagedPolicyName("CloudWatchAgentServerPolicy"),
+    );
 
     // Add policy for DynamoDB access
-    role.addToPolicy(new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      // actions: [
-      //   'dynamodb:PutItem',
-      //   'dynamodb:GetItem',
-      //   'dynamodb:UpdateItem',
-      //   'dynamodb:DeleteItem',
-      //   'dynamodb:Query',
-      //   'dynamodb:Scan'
-      // ],
-      actions: ["dynamodb:*", "lambda:*"],
-      //resources: ['arn:aws:dynamodb:*:*:table/tables_streams'],
-      // note change ^ to stream_table_map for production
-      resources: "*"
-    }));
+    role.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["dynamodb:*", "lambda:*"],
+        //resources: ['arn:aws:dynamodb:*:*:table/tables_streams'],
+        // note change ^ to stream_table_map for production
+        resources: "*",
+      }),
+    );
 
     const ubuntuAmi = ec2.MachineImage.fromSsmParameter(
-      '/aws/service/canonical/ubuntu/server/focal/stable/current/amd64/hvm/ebs-gp2/ami-id',
-      { os: ec2.OperatingSystemType.LINUX }
+      "/aws/service/canonical/ubuntu/server/focal/stable/current/amd64/hvm/ebs-gp2/ami-id",
+      { os: ec2.OperatingSystemType.LINUX },
     );
 
     const userData = ec2.UserData.forLinux();
     userData.addCommands(
-      'apt-get update',
-      'apt-get install -y docker.io awscli',
-      'systemctl start docker',
-      'systemctl enable docker',
-      'usermod -aG docker ubuntu',
-      'CH_HOST=$(aws ssm get-parameter --name /helios/clickhouse/ip --query "Parameter.Value" --output text --region ' + this.region + ')',
-      'echo "CH_HOST=$CH_HOST" > /home/ubuntu/.env',
-      'docker pull kuanchiliao/helios-flask-amd:dev',
-      'docker run -d -p 5000:5000 --env-file /home/ubuntu/.env --name flask-app kuanchiliao/helios-flask-amd:dev'
+      "apt-get update",
+      "apt-get install -y docker.io awscli",
+      "systemctl start docker",
+      "systemctl enable docker",
+      "usermod -aG docker ubuntu",
+      `CH_HOST=$(aws ssm get-parameter --name /helios/clickhouse/ip --query "Parameter.Value" --output text --region ${props.env.region})`,
+      `echo "CH_HOST=$CH_HOST\nCHAT_GPT_API_KEY=${process.env.chatGptApiKey}" > /home/ubuntu/.env`,
+      "docker pull kuanchiliao/helios-flask-amd:dev",
+      "docker run -d -p 5000:5000 --env-file /home/ubuntu/.env --name flask-app kuanchiliao/helios-flask-amd:dev",
     );
 
-    const instance = new ec2.Instance(this, 'FlaskInstance', {
+    const instance = new ec2.Instance(this, "FlaskInstance", {
       vpc,
-      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.MICRO),
+      instanceType: ec2.InstanceType.of(
+        ec2.InstanceClass.T2,
+        ec2.InstanceSize.MICRO,
+      ),
       machineImage: ubuntuAmi,
       securityGroup: flaskSecurityGroup,
       vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
@@ -82,16 +100,16 @@ class FlaskEc2Stack extends Stack {
       userData: userData,
     });
 
-    new CfnOutput(this, 'FlaskInstancePublicIp', {
+    new CfnOutput(this, "FlaskInstancePublicIp", {
       value: instance.instancePublicIp,
-      description: 'Public IP address of the Flask EC2 instance',
-      exportName: 'FlaskInstancePublicIp',
+      description: "Public IP address of the Flask EC2 instance",
+      exportName: "FlaskInstancePublicIp",
     });
 
-    new CfnOutput(this, 'FlaskInstanceId', {
+    new CfnOutput(this, "FlaskInstanceId", {
       value: instance.instanceId,
-      description: 'Flask EC2 Instance ID',
-      exportName: 'FlaskInstanceId',
+      description: "Flask EC2 Instance ID",
+      exportName: "FlaskInstanceId",
     });
 
     // new CfnOutput(this, 'SecurityGroupId', {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "bin": {
     "cdk_deploy": "bin/cdk_deploy.js",
     "helios": "bin/cli.js"
-  }, 
+  },
   "scripts": {
     "build": "echo \"The build step is not required when using JavaScript!\" && exit 0",
     "cdk": "cdk",
@@ -20,6 +20,7 @@
     "aws-cdk-lib": "^2.149.0",
     "cdk-ec2-key-pair": "^4.0.1",
     "constructs": "^10.0.0",
+    "dotenv": "^16.4.5",
     "ora": "5.4.1"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -34,16 +34,16 @@ main() {
         echo "setup_cdk.sh or assume_role.sh not found in the current directory."
         exit 1
     fi
-    
+
     echo "Running setup_cdk.sh..."
-    ./setup_cdk.sh "$PROFILE"
-    
+    bash ./setup_cdk.sh "$PROFILE"
+
     echo "Deploying IamStack..."
     cdk deploy IamStack --require-approval never
-    
+
     echo "Assuming deployment role..."
-    ./assume_role.sh "$PROFILE"
-    
+    bash ./assume_role.sh "$PROFILE"
+
     echo "Deploying all stacks..."
 
     if cdk deploy --all --require-approval never; then


### PR DESCRIPTION
## Overview

Prompts user to enter a ChatGPT API Key. Is optional to provide this key, though if they do will allow them to use our web app quarantine table analysis feature.

## Changes
- Prompts user in `src/utils/run-deploy.js` --> for future, could extract this to a helper
- Stores their response as a variable in Node's `process.env`
- The FlaskEc2Stack on deployment references `process.env` to store the key as a variable in `/home/ubuntu/.env` on the EC2 instance

## Notes for Reviewers
- Tried multiple other options for storing the key. Would be nice if could pass it as a prop in `cdk_deploy` similar to how we pass a user's AWS region, but the option we ended up going with using `process.env` was simpler to implement for v1