### PR TITLE
Feat/add ebs clickhouse ec2

### DIFF
--- a/lib/clickhouse-ec2-stack.js
+++ b/lib/clickhouse-ec2-stack.js
@@ -1,4 +1,4 @@
-const { Stack, CfnOutput, Fn } = require('aws-cdk-lib');
+const { Stack, CfnOutput, Fn, Size } = require('aws-cdk-lib');
 const ec2 = require('aws-cdk-lib/aws-ec2');
 const iam = require('aws-cdk-lib/aws-iam');
 const ssm = require('aws-cdk-lib/aws-ssm');
@@ -75,7 +75,6 @@ class ClickhouseEc2Stack extends Stack {
     const userData = ec2.UserData.forLinux();
     userData.addCommands(
       fs.readFileSync(path.join(__dirname, '..', 'scripts', 'install_clickhouse.sh'), 'utf8'),
-      // `export REGION=${props.env.region}`,
       'sudo mkdir -p /opt/scripts/',
       fs.readFileSync(path.join(__dirname, '..', 'scripts', 'install_clickhouse_backup.sh'), 'utf8'),
       fs.readFileSync(path.join(__dirname, '..', 'scripts', 'clickhouse_backup.sh'), 'utf8'),
@@ -85,6 +84,13 @@ class ClickhouseEc2Stack extends Stack {
       'sudo systemctl restart cron'
     );
 
+    const ebsVolume = new ec2.Volume(this, 'ClickHouseEBSVolume', {
+      availabilityZone: props.availabilityZones[0], // Use the first AZ
+      size: Size.gibibytes(1000),
+      volumeType: ec2.EbsDeviceVolumeType.GP3,
+      encrypted: false,
+    });
+
     const instance = new ec2.Instance(this, 'ClickHouseInstance', {
       vpc,
       instanceType: ec2.InstanceType.of(ec2.InstanceClass.T2, ec2.InstanceSize.LARGE),
@@ -93,7 +99,31 @@ class ClickhouseEc2Stack extends Stack {
       vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
       role: role,
       userData: userData,
+      blockDevices: [
+        {
+          deviceName: '/dev/sda1',
+          volume: ec2.BlockDeviceVolume.ebs(100, {
+            volumeType: ec2.EbsDeviceVolumeType.GP3,
+            encrypted: true,
+          }),
+        },
+      ],
     });
+
+    new ec2.CfnVolumeAttachment(this, 'EBSVolumeAttachment', {
+      volumeId: ebsVolume.volumeId,
+      instanceId: instance.instanceId,
+      device: '/dev/sdf',
+    });
+
+    // Add commands to set up the EBS volume
+    userData.addCommands(
+      'sudo mkfs -t ext4 /dev/nvme1n1',
+      'sudo mkdir -p /var/lib/clickhouse',
+      'sudo mount /dev/nvme1n1 /var/lib/clickhouse',
+      'echo "/dev/nvme1n1 /var/lib/clickhouse ext4 defaults,nofail 0 2" | sudo tee -a /etc/fstab',
+      'sudo chown clickhouse:clickhouse /var/lib/clickhouse'
+    );
 
     new ssm.StringParameter(this, 'ClickhouseIpParameter', {
       parameterName: '/helios/clickhouse/ip',

--- a/lib/dynamodb-stack.js
+++ b/lib/dynamodb-stack.js
@@ -8,7 +8,7 @@ class DynamoDbStack extends Stack {
     super(scope, id, props);
 
     const table = new dynamodb.Table(this, 'StreamTableMap', {
-      tableName: 'tables_streams',
+      tableName: 'stream_table_map',
       // change this ^ to stream_table_map in production
       partitionKey: { name: 'stream_id', type: dynamodb.AttributeType.STRING },
       sortKey: { name: 'table_id', type: dynamodb.AttributeType.STRING },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "aws-cdk-lib": "^2.149.0",
         "cdk-ec2-key-pair": "^4.0.1",
         "constructs": "^10.0.0",
+        "dotenv": "^16.4.5",
         "ora": "5.4.1"
       },
       "bin": {
@@ -2396,9 +2397,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.149.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.149.0.tgz",
-      "integrity": "sha512-bmbgnF2dEYlsZlVaNoSfcjyIUirnvmsvNXJwBMmUCZn2IZ+YWvkMv+rr4e/GO3gPKrdNzew1jNVvHSYxlun6rA==",
+      "version": "2.151.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.151.0.tgz",
+      "integrity": "sha512-SIzzOGSYO+s1f+y2zyGKK8wH5JmN+nkrGOL28iHzmx9lXK0NaT0+d5sjTbzLo2C8iogzbR91yGnIKze0GzZXHg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -3283,6 +3284,17 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.5",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.5.tgz",
+      "integrity": "sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/electron-to-chromium": {


### PR DESCRIPTION
## Overview
Add EBS volume for Clickhouse data

## Changes
- Made changes in CDK to create volume and mount it

## Notes for Reviewer
- Our EC2's already deploy with a default EBS volume, we just added another one for the Clickhouse EC2 and set the root volume to 100GiB
- For Clickhouse EC2, the root volume has the Clickhouse software, and the other volume has the Clickhouse data
- No issues so far